### PR TITLE
fix: adapt to yargs v18

### DIFF
--- a/map-utilities/generate-map.js
+++ b/map-utilities/generate-map.js
@@ -1,7 +1,7 @@
 const { MudletMapReader } = require("mudlet-map-binary-reader");
 const yargs = require("yargs");
 
-const argv = yargs(process.yargs).option("base-dir", {
+const argv = yargs(process.argv).option("base-dir", {
   default: ".",
   type: "string",
   description: "The base directory to use the Maps directory from",

--- a/map-utilities/generate-map.js
+++ b/map-utilities/generate-map.js
@@ -1,7 +1,7 @@
 const { MudletMapReader } = require("mudlet-map-binary-reader");
 const yargs = require("yargs");
 
-const argv = yargs.option("base-dir", {
+const argv = yargs(process.yargs).option("base-dir", {
   default: ".",
   type: "string",
   description: "The base directory to use the Maps directory from",


### PR DESCRIPTION
This is a fix necessary to let the CI jobs run again. I missed this breaking change from the changelog when updating yargs to version 18.