### PR TITLE
Fix workflow pwn request vulnerabilities

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -2,15 +2,17 @@ name: DangerJS
 
 on: pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
-        fetch-depth: 0
+        fetch-depth: 1
     - name: Use Node.js
       uses: actions/setup-node@v6.2.0
     - name: Install yarn dependencies

--- a/.github/workflows/json-diff.yml
+++ b/.github/workflows/json-diff.yml
@@ -2,31 +2,35 @@ name: JSON diff
 
 on: pull_request_target
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   json-diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout current version
+      - name: Checkout base version
         uses: actions/checkout@v6
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
-          fetch-depth: 0
-          path: current
-      - name: Checkout old version
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-          repository: ${{ github.event.pull_request.base.repo.full_name }}
           fetch-depth: 0
           path: old
-
+      - name: Checkout base again for PR overlay
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          path: current
+      - name: Fetch PR changes into current
+        working-directory: current
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          git checkout pr-head
 
       - uses: actions/setup-node@v6.2.0
       - name: Install dependencies
         run: |
           sudo apt-get install jq diffutils
-
 
       - name: Generate json map files for diffing
         run: |

--- a/.github/workflows/show-map-diffs.yml
+++ b/.github/workflows/show-map-diffs.yml
@@ -2,16 +2,22 @@ name: Map diffs
 
 on: [pull_request_target]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   map-diff:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout base
         uses: actions/checkout@v6
         with:
-          ref: ${{github.event.pull_request.head.ref}}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
+      - name: Fetch PR head
+        run: |
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          git checkout pr-head
 
       - name: Check if the map was changed in this PR
         id: map-change-detected


### PR DESCRIPTION
Fixes critical security vulnerability in CI workflows where `pull_request_target` workflows checkout and execute untrusted PR code.

**Changes:**
- **danger.yaml**: Remove PR head checkout (DangerJS only uses GitHub API features, not local files). Add `permissions` block to limit GITHUB_TOKEN scope.
- **json-diff.yml**: Fetch PR via `origin pull/$N/head` ref instead of directly from fork repo. Add `permissions` block.
- **show-map-diffs.yml**: Fetch PR via `origin pull/$N/head` ref instead of directly from fork repo. Add `permissions` block.

**Context:** Discovered via a real attack on StarmournCrowdmap (PR #122) which exploited `danger.yaml` to exfiltrate CI environment variables including GITHUB_TOKEN via a malicious npm preinstall script.